### PR TITLE
Fix #50: Fix JavaDoc warnings

### DIFF
--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/configuration/WebApplicationConfig.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/configuration/WebApplicationConfig.java
@@ -16,13 +16,13 @@
 package io.getlime.security.powerauth.app.dataadapter.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
@@ -32,7 +32,7 @@ import java.util.List;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Configuration
-public class WebApplicationConfig extends WebMvcConfigurerAdapter {
+public class WebApplicationConfig implements WebMvcConfigurer {
 
     /**
      * Custom object mapper to make sure that dates and other values serialize
@@ -43,10 +43,11 @@ public class WebApplicationConfig extends WebMvcConfigurerAdapter {
     private ObjectMapper objectMapper() {
         Jackson2ObjectMapperFactoryBean bean = new Jackson2ObjectMapperFactoryBean();
         bean.setIndentOutput(true);
-        bean.setDateFormat(new ISO8601DateFormat());
         bean.afterPropertiesSet();
         ObjectMapper objectMapper = bean.getObject();
         objectMapper.registerModule(new JodaModule());
+        // replacement for ISO8601DateFormat which is deprecated
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         return objectMapper;
     }
 
@@ -67,7 +68,6 @@ public class WebApplicationConfig extends WebMvcConfigurerAdapter {
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.add(mappingJackson2HttpMessageConverter());
-        super.configureMessageConverters(converters);
     }
 
 }


### PR DESCRIPTION
This change fixes JavaDoc deprecation warnings by completing migration to Spring Boot 2.