### PR TITLE
Backport fix of #65: Validation fails because of missing enclosing method

### DIFF
--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/AuthenticationController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/AuthenticationController.java
@@ -38,7 +38,6 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.lang.invoke.MethodHandles;
 
 /**
  * Controller class which handles user authentication.
@@ -87,8 +86,8 @@ public class AuthenticationController {
     @RequestMapping(value = "/authenticate", method = RequestMethod.POST)
     public @ResponseBody ObjectResponse<AuthenticationResponse> authenticate(@Valid @RequestBody ObjectRequest<AuthenticationRequest> request, BindingResult result) throws MethodArgumentNotValidException, DataAdapterRemoteException, AuthenticationFailedException {
         if (result.hasErrors()) {
-            // Call of getEnclosingMethod() on class found using MethodHandles.lookup() returns a reference to current method
-            MethodParameter methodParam = new MethodParameter(MethodHandles.lookup().lookupClass().getEnclosingMethod(),0);
+            // Call of getEnclosingMethod() on new object returns a reference to current method
+            MethodParameter methodParam = new MethodParameter(new Object(){}.getClass().getEnclosingMethod(), 0);
             logger.warn("The authenticate request failed due to validation errors");
             throw new MethodArgumentNotValidException(methodParam, result);
         }

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/SMSAuthorizationController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/SMSAuthorizationController.java
@@ -39,7 +39,6 @@ import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.lang.invoke.MethodHandles;
 
 /**
  * Controller class which handles SMS OTP authorization.
@@ -92,8 +91,8 @@ public class SMSAuthorizationController {
     @RequestMapping(value = "create", method = RequestMethod.POST)
     public @ResponseBody ObjectResponse<CreateSMSAuthorizationResponse> createAuthorizationSMS(@Valid @RequestBody ObjectRequest<CreateSMSAuthorizationRequest> request, BindingResult result) throws MethodArgumentNotValidException, DataAdapterRemoteException, SMSAuthorizationFailedException, InvalidOperationContextException {
         if (result.hasErrors()) {
-            // Call of getEnclosingMethod() on class found using MethodHandles.lookup() returns a reference to current method
-            MethodParameter methodParam = new MethodParameter(MethodHandles.lookup().lookupClass().getEnclosingMethod(),0);
+            // Call of getEnclosingMethod() on new object returns a reference to current method
+            MethodParameter methodParam = new MethodParameter(new Object(){}.getClass().getEnclosingMethod(), 0);
             logger.warn("The createAuthorizationSMS request failed due to validation errors");
             throw new MethodArgumentNotValidException(methodParam, result);
         }


### PR DESCRIPTION
Let's backport this fix into release `0.21.0` because of impact on user experience. "Uknown error" is displayed when form validation fails instead instead of regular validation errors.