### PR TITLE
Fix #88: Updates for APPROVAL_SCA authentication method

### DIFF
--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/service/DataAdapterService.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/service/DataAdapterService.java
@@ -92,8 +92,8 @@ public class DataAdapterService implements DataAdapter {
         // Replace mock bank account data with real data loaded from the bank backend.
         // In case the bank account selection is disabled, return an empty list.
 
-        if (!"authorize_payment".equals(operationName) && !"authorize_payment_sca".equals(operationName)) {
-            // return empty list for operations other than authorize_payment
+        if ((!"authorize_payment".equals(operationName) && !"authorize_payment_sca".equals(operationName))) {
+            // return empty list for operations other than authorize_payment or authorize_payment_sca
             return new DecorateOperationFormDataResponse(formData);
         }
 

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/service/DataAdapterService.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/service/DataAdapterService.java
@@ -92,7 +92,7 @@ public class DataAdapterService implements DataAdapter {
         // Replace mock bank account data with real data loaded from the bank backend.
         // In case the bank account selection is disabled, return an empty list.
 
-        if (!"authorize_payment".equals(operationName)) {
+        if (!"authorize_payment".equals(operationName) && !"authorize_payment_sca".equals(operationName)) {
             // return empty list for operations other than authorize_payment
             return new DecorateOperationFormDataResponse(formData);
         }
@@ -175,11 +175,12 @@ public class DataAdapterService implements DataAdapter {
         List<String> digestItems = new ArrayList<>();
         switch (operationName) {
             case "login":
-            case "login_2fa": {
+            case "login_sca": {
                 digestItems.add(operationName);
                 break;
             }
-            case "authorize_payment": {
+            case "authorize_payment":
+            case "authorize_payment_sca": {
                 AmountAttribute amountAttribute = operationValueExtractionService.getAmount(operationContext);
                 String account = operationValueExtractionService.getAccount(operationContext);
                 BigDecimal amount = amountAttribute.getAmount();
@@ -207,11 +208,12 @@ public class DataAdapterService implements DataAdapter {
         String[] messageArgs;
         switch (operationName) {
             case "login":
-            case "login_2fa": {
+            case "login_sca": {
                 messageArgs = new String[]{authorizationCode.getCode()};
                 break;
             }
-            case "authorize_payment": {
+            case "authorize_payment":
+            case "authorize_payment_sca": {
                 AmountAttribute amountAttribute = operationValueExtractionService.getAmount(operationContext);
                 String account = operationValueExtractionService.getAccount(operationContext);
                 BigDecimal amount = amountAttribute.getAmount();
@@ -235,7 +237,7 @@ public class DataAdapterService implements DataAdapter {
 
     @Override
     public CreateConsentFormResponse createConsentForm(String userId, String organizationId, OperationContext operationContext, String lang) throws DataAdapterRemoteException, InvalidOperationContextException {
-        if ("login".equals(operationContext.getName()) || "login_2fa".equals(operationContext.getName())) {
+        if ("login".equals(operationContext.getName()) || "login_sca".equals(operationContext.getName())) {
             // Create default consent
             CreateConsentFormResponse response = new CreateConsentFormResponse();
             if ("cs".equals(lang)) {
@@ -256,7 +258,7 @@ public class DataAdapterService implements DataAdapter {
             response.getOptions().add(option1);
             return response;
         }
-        if ("authorize_payment".equals(operationContext.getName())) {
+        if ("authorize_payment".equals(operationContext.getName()) || "authorize_payment_sca".equals(operationContext.getName())) {
             CreateConsentFormResponse response = new CreateConsentFormResponse();
             if ("cs".equals(lang)) {
                 response.setConsentHtml("Tímto potvrzuji, že jsem inicioval tuto platební operaci a souhlasím s jejím dokončením.");
@@ -295,7 +297,7 @@ public class DataAdapterService implements DataAdapter {
         if (options == null || options.isEmpty()) {
             throw new InvalidConsentDataException("Missing options for consent");
         }
-        if ("login".equals(operationContext.getName()) || "login_2fa".equals(operationContext.getName())) {
+        if ("login".equals(operationContext.getName()) || "login_sca".equals(operationContext.getName())) {
             if (options.size() != 1) {
                 throw new InvalidConsentDataException("Unexpected options count for consent");
             }
@@ -326,7 +328,7 @@ public class DataAdapterService implements DataAdapter {
             }
             return response;
         }
-        if ("authorize_payment".equals(operationContext.getName())) {
+        if ("authorize_payment".equals(operationContext.getName()) || "authorize_payment_sca".equals(operationContext.getName())) {
             if (options.size() != 2) {
                 throw new InvalidConsentDataException("Unexpected options count for consent");
             }

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/validation/CreateSmsAuthorizationRequestValidator.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/validation/CreateSmsAuthorizationRequestValidator.java
@@ -105,10 +105,11 @@ public class CreateSmsAuthorizationRequestValidator implements Validator {
         if (operationName != null) {
             switch (operationName) {
                 case "login":
-                case "login_2fa":
+                case "login_sca":
                     // no field validation required
                     break;
                 case "authorize_payment":
+                case "authorize_payment_sca":
                     AmountAttribute amountAttribute;
                     try {
                         amountAttribute = operationValueExtractionService.getAmount(authRequest.getOperationContext());

--- a/powerauth-data-adapter/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-data-adapter/src/main/resources/static/resources/messages_cs.properties
@@ -1,4 +1,5 @@
 login.smsText=Autorizační kód pro přihlášení je {0}.
-login_2fa.smsText=Autorizační kód pro přihlášení je {0}.
+login_sca.smsText=Autorizační kód pro přihlášení je {0}.
 authorize_payment.smsText=Autorizační kód pro platbu {0} {1} na účet {2} je {3}.
+authorize_payment_sca.smsText=Autorizační kód pro platbu {0} {1} na účet {2} je {3}.
 operationReview.balanceTooLow=Nízký zůstatek na účtu

--- a/powerauth-data-adapter/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-data-adapter/src/main/resources/static/resources/messages_en.properties
@@ -1,4 +1,5 @@
 login.smsText=Authorization code for login is {0}.
-login_2fa.smsText=Authorization code for login is {0}.
+login_sca.smsText=Authorization code for login is {0}.
 authorize_payment.smsText=Authorization code for payment of {0} {1} to account {2} is {3}.
+authorize_payment_sca.smsText=Authorization code for payment of {0} {1} to account {2} is {3}.
 operationReview.balanceTooLow=Low account balance


### PR DESCRIPTION
Added `authorize_payment_sca` operation name and renamed `login_2fa` to `login_sca` in accordance with implementation of `APPROVAL_SCA` method in Web Flow.