### PR TITLE
Fix #104: Handle unsupported language in consent form

### DIFF
--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/service/DataAdapterService.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/service/DataAdapterService.java
@@ -273,6 +273,10 @@ public class DataAdapterService implements DataAdapter {
 
     @Override
     public CreateConsentFormResponse createConsentForm(String userId, String organizationId, OperationContext operationContext, String lang) throws DataAdapterRemoteException, InvalidOperationContextException {
+        // Fallback to English for unsupported languages, see: https://github.com/wultra/powerauth-webflow-customization/issues/104
+        if (!"cs".equals(lang) && !"en".equals(lang)) {
+            lang = "en";
+        }
         // Generate response with consent text and options based on requested language.
         if ("login".equals(operationContext.getName()) || "login_sca".equals(operationContext.getName())) {
             // Create default consent
@@ -330,6 +334,10 @@ public class DataAdapterService implements DataAdapter {
 
     @Override
     public ValidateConsentFormResponse validateConsentForm(String userId, String organizationId, OperationContext operationContext, String lang, List<ConsentOption> options) throws DataAdapterRemoteException, InvalidOperationContextException, InvalidConsentDataException {
+        // Fallback to English for unsupported languages, see: https://github.com/wultra/powerauth-webflow-customization/issues/104
+        if (!"cs".equals(lang) && !"en".equals(lang)) {
+            lang = "en";
+        }
         // Validate consent form options and return response with result of validation and optional error messages.
         ValidateConsentFormResponse response = new ValidateConsentFormResponse();
         if (options == null || options.isEmpty()) {

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/validation/ConsentFormRequestValidator.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/validation/ConsentFormRequestValidator.java
@@ -82,7 +82,7 @@ public class ConsentFormRequestValidator implements Validator {
             if (request.getOperationContext() != null) {
                 validateOperationName(request.getOperationContext().getName(), errors);
             }
-            validateLanguage(request.getLang(), errors);
+            validateLanguage(errors);
         } else if (objectRequest.getRequestObject() instanceof ValidateConsentFormRequest) {
             ObjectRequest<ValidateConsentFormRequest> requestObject = (ObjectRequest<ValidateConsentFormRequest>) o;
             ValidateConsentFormRequest request = requestObject.getRequestObject();
@@ -91,7 +91,7 @@ public class ConsentFormRequestValidator implements Validator {
             if (request.getOperationContext() != null) {
                 validateOperationName(request.getOperationContext().getName(), errors);
             }
-            validateLanguage(request.getLang(), errors);
+            validateLanguage(errors);
             validateOptions(request.getOptions(), errors);
         } else if (objectRequest.getRequestObject() instanceof SaveConsentFormRequest) {
             ObjectRequest<SaveConsentFormRequest> requestObject = (ObjectRequest<SaveConsentFormRequest>) o;
@@ -125,11 +125,9 @@ public class ConsentFormRequestValidator implements Validator {
         }
     }
 
-    private void validateLanguage(String lang, Errors errors) {
+    private void validateLanguage(Errors errors) {
         ValidationUtils.rejectIfEmptyOrWhitespace(errors, "requestObject.lang", "consent.invalidRequest");
-        if (lang != null && !lang.equals("cs") && !lang.equals("en")) {
-            errors.rejectValue("requestObject.lang", "consent.invalidRequest");
-        }
+        // Do not validate lang parameter, fallback to "en" instead, see: https://github.com/wultra/powerauth-webflow-customization/issues/104
     }
 
     private void validateOptions(List<ConsentOption> options, Errors errors) {


### PR DESCRIPTION
Instead of validating supported languages a fallback to "en" is done for unsupported languages. This behaviour is in sync with Web Flow which also falls back to "en" for unsupported languages in the UI.