### PR TITLE
Fix #118: Update maximum password length validation

### DIFF
--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/validation/AuthenticationRequestValidator.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/impl/validation/AuthenticationRequestValidator.java
@@ -113,7 +113,8 @@ public class AuthenticationRequestValidator implements Validator {
         AuthenticationContext authenticationContext = authRequest.getAuthenticationContext();
         PasswordProtectionType passwordProtection = authenticationContext.getPasswordProtection();
         if (passwordProtection == PasswordProtectionType.NO_PROTECTION) {
-            if (password != null && password.length() > 30) {
+            // See: https://owasp.org/www-project-cheat-sheets/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls
+            if (password != null && password.length() > 128) {
                 errors.rejectValue(PASS_FIELD, "login.password.long");
             }
         } else {


### PR DESCRIPTION
Let's switch to maximum password length recommended by OWASP by default.