### PR TITLE
Fix #157: Method for delivering OTP code generated by Next Step

### DIFF
--- a/powerauth-data-adapter/pom.xml
+++ b/powerauth-data-adapter/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>powerauth-data-adapter</artifactId>
     <groupId>io.getlime.security</groupId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>powerauth-data-adapter</name>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-data-adapter-model</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.getlime.security</groupId>

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/api/DataAdapter.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/api/DataAdapter.java
@@ -137,6 +137,22 @@ public interface DataAdapter {
     CreateSmsAuthorizationResponse createAndSendAuthorizationSms(String userId, String organizationId, AccountStatus accountStatus, AuthMethod authMethod, OperationContext operationContext, String lang) throws InvalidOperationContextException, DataAdapterRemoteException;
 
     /**
+     * Send an authorization SMS message with generated authorization code.
+     * @param userId User ID.
+     * @param organizationId Organization ID.
+     * @param accountStatus User account status.
+     * @param authMethod Authentication method.
+     * @param operationContext Operation context.
+     * @param messageId Message ID.
+     * @param authorizationCode Authorization code.
+     * @param lang Language for localization.
+     * @return Message ID.
+     * @throws InvalidOperationContextException Thrown when operation context is invalid.
+     * @throws DataAdapterRemoteException Thrown when remote communication fails or SMS message could not be delivered.
+     */
+    SendAuthorizationSmsResponse sendAuthorizationSms(String userId, String organizationId, AccountStatus accountStatus, AuthMethod authMethod, OperationContext operationContext, String messageId, String authorizationCode, String lang) throws InvalidOperationContextException, DataAdapterRemoteException;
+
+    /**
      * Verify authorization code from SMS message.
      * @param userId User ID.
      * @param organizationId Organization ID.

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/SmsAuthorizationController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/SmsAuthorizationController.java
@@ -88,7 +88,7 @@ public class SmsAuthorizationController {
         logger.info("Received createAuthorizationSms request, operation ID: {}", request.getRequestObject().getOperationContext().getId());
         CreateSmsAuthorizationRequest smsRequest = request.getRequestObject();
 
-        // Create authorization SMS and persist it.
+        // Create authorization SMS and persist it
         String userId = smsRequest.getUserId();
         String organizationId = smsRequest.getOrganizationId();
         AccountStatus accountStatus = smsRequest.getAccountStatus();
@@ -114,7 +114,7 @@ public class SmsAuthorizationController {
         logger.info("Received sendAuthorizationSms request, operation ID: {}", request.getRequestObject().getOperationContext().getId());
         SendAuthorizationSmsRequest smsRequest = request.getRequestObject();
 
-        // Create authorization SMS and persist it.
+        // Create authorization SMS
         String userId = smsRequest.getUserId();
         String organizationId = smsRequest.getOrganizationId();
         AccountStatus accountStatus = smsRequest.getAccountStatus();

--- a/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/SmsAuthorizationController.java
+++ b/powerauth-data-adapter/src/main/java/io/getlime/security/powerauth/app/dataadapter/controller/SmsAuthorizationController.java
@@ -20,14 +20,16 @@ import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.app.dataadapter.api.DataAdapter;
 import io.getlime.security.powerauth.app.dataadapter.exception.DataAdapterRemoteException;
 import io.getlime.security.powerauth.app.dataadapter.exception.InvalidOperationContextException;
-import io.getlime.security.powerauth.app.dataadapter.impl.validation.CreateSmsAuthorizationRequestValidator;
+import io.getlime.security.powerauth.app.dataadapter.impl.validation.AuthorizationSmsRequestValidator;
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.AuthenticationContext;
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.OperationContext;
 import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AccountStatus;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.CreateSmsAuthorizationRequest;
+import io.getlime.security.powerauth.lib.dataadapter.model.request.SendAuthorizationSmsRequest;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.VerifySmsAndPasswordRequest;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.VerifySmsAuthorizationRequest;
 import io.getlime.security.powerauth.lib.dataadapter.model.response.CreateSmsAuthorizationResponse;
+import io.getlime.security.powerauth.lib.dataadapter.model.response.SendAuthorizationSmsResponse;
 import io.getlime.security.powerauth.lib.dataadapter.model.response.VerifySmsAndPasswordResponse;
 import io.getlime.security.powerauth.lib.dataadapter.model.response.VerifySmsAuthorizationResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
@@ -50,7 +52,7 @@ public class SmsAuthorizationController {
 
     private static final Logger logger = LoggerFactory.getLogger(SmsAuthorizationController.class);
 
-    private final CreateSmsAuthorizationRequestValidator requestValidator;
+    private final AuthorizationSmsRequestValidator requestValidator;
     private final DataAdapter dataAdapter;
 
     /**
@@ -59,7 +61,7 @@ public class SmsAuthorizationController {
      * @param dataAdapter Data adapter.
      */
     @Autowired
-    public SmsAuthorizationController(CreateSmsAuthorizationRequestValidator requestValidator, DataAdapter dataAdapter) {
+    public SmsAuthorizationController(AuthorizationSmsRequestValidator requestValidator, DataAdapter dataAdapter) {
         this.requestValidator = requestValidator;
         this.dataAdapter = dataAdapter;
     }
@@ -96,6 +98,34 @@ public class SmsAuthorizationController {
         CreateSmsAuthorizationResponse response = dataAdapter.createAndSendAuthorizationSms(userId, organizationId, accountStatus, authMethod, operationContext, lang);
 
         logger.info("The createAuthorizationSms request succeeded, operation ID: {}", request.getRequestObject().getOperationContext().getId());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Send a new SMS OTP authorization message.
+     *
+     * @param request Request data.
+     * @return Response with message ID.
+     * @throws DataAdapterRemoteException Thrown in case of remote communication errors.
+     * @throws InvalidOperationContextException Thrown in case operation context is invalid.
+     */
+    @PostMapping(value = "send")
+    public ObjectResponse<SendAuthorizationSmsResponse> sendAuthorizationSms(@Valid @RequestBody ObjectRequest<SendAuthorizationSmsRequest> request) throws DataAdapterRemoteException, InvalidOperationContextException {
+        logger.info("Received sendAuthorizationSms request, operation ID: {}", request.getRequestObject().getOperationContext().getId());
+        SendAuthorizationSmsRequest smsRequest = request.getRequestObject();
+
+        // Create authorization SMS and persist it.
+        String userId = smsRequest.getUserId();
+        String organizationId = smsRequest.getOrganizationId();
+        AccountStatus accountStatus = smsRequest.getAccountStatus();
+        AuthMethod authMethod = smsRequest.getAuthMethod();
+        OperationContext operationContext = smsRequest.getOperationContext();
+        String messageId = smsRequest.getMessageId();
+        String authorizationCode = smsRequest.getAuthorizationCode();
+        String lang = smsRequest.getLang();
+        SendAuthorizationSmsResponse response = dataAdapter.sendAuthorizationSms(userId, organizationId, accountStatus, authMethod, operationContext, messageId, authorizationCode, lang);
+
+        logger.info("The sendAuthorizationSms request succeeded, operation ID: {}", request.getRequestObject().getOperationContext().getId());
         return new ObjectResponse<>(response);
     }
 


### PR DESCRIPTION
A new method which will be used when OTP code is generated by Next Step and DA is only used to prepare the message and send the OTP via SMS.

I also removed the fake SMS delivery responses, the fake authorization logic is now handled in Web Flow to avoid sending such fake requests through both Next Step and Data Adapter.