### PR TITLE
Fix #181: Exclude log4j-api dependency

### DIFF
--- a/powerauth-data-adapter/pom.xml
+++ b/powerauth-data-adapter/pom.xml
@@ -73,6 +73,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This change should resolve any future questions about the Log4J dependencies included in Spring logging.